### PR TITLE
Insert new points with video time

### DIFF
--- a/map_page.html
+++ b/map_page.html
@@ -596,17 +596,19 @@
 		return;
 	}
 	
-	/*
-    if (selectedIndex == null) {
-        alert("No point selected ⇒ cannot insert new point.");
-        addNewPointMode = false;
-        document.body.style.cursor = "";
-        return;
-    }*/
+	// => es gibt nur diesen einen Punkt
+	let ll = ol.proj.toLonLat(evt.coordinate);
+
+  if (selectedIndex == null) {
+    channelObj.newPointInserted(ll[1], ll[0], -3); //-3 will correspond to no selection (to display error if not in easy insert mode)
+    //alert("No point selected ⇒ cannot insert new point.");
+    addNewPointMode = false;
+    document.body.style.cursor = "";
+    return;
+  }
 	
 	if (maxIdx === 0) {
-		// => es gibt nur diesen einen Punkt
-		let ll = ol.proj.toLonLat(evt.coordinate);
+		
 		if (channelObj && channelObj.newPointInserted) {
 		// => Immer hinten anfügen (idx = -1)
 		channelObj.newPointInserted(ll[1], ll[0], -1);
@@ -619,7 +621,6 @@
 	
     if (selectedIndex === 0) {
         // => Vorne einfügen
-        let ll = ol.proj.toLonLat(evt.coordinate);
         if (channelObj && channelObj.newPointInserted) {
             channelObj.newPointInserted(ll[1], ll[0], -2); 
             // -2 signalisiert "vor dem ersten Punkt"
@@ -635,7 +636,6 @@
         let mIdx = getMaxIndex();
         if (selectedIndex === mIdx && mIdx >= 0) {
             // => "hinten" anfügen => idx=-1
-            let ll = ol.proj.toLonLat(evt.coordinate);
             if (channelObj && channelObj.newPointInserted) {
                 channelObj.newPointInserted(ll[1], ll[0], -1);
             }
@@ -661,7 +661,6 @@
 
         if (!foundLine || !closestCoord) {
             // => index = -1 => "am Ende"
-            let ll = ol.proj.toLonLat(evt.coordinate);
             if (channelObj && channelObj.newPointInserted) {
                 channelObj.newPointInserted(ll[1], ll[0], -1);
             }
@@ -674,7 +673,6 @@
         // Hier: Zwischen Segmenten
         let coords = foundLine.getGeometry().getCoordinates();
         if (coords.length < 2) {
-            let ll = ol.proj.toLonLat(evt.coordinate);
             channelObj.newPointInserted(ll[1], ll[0], -1);
         } else {
             let seg = findSegmentIndexForClosestCoord(coords, closestCoord);

--- a/map_page.html
+++ b/map_page.html
@@ -596,13 +596,13 @@
 		return;
 	}
 	
-	
+	/*
     if (selectedIndex == null) {
         alert("No point selected ⇒ cannot insert new point.");
         addNewPointMode = false;
         document.body.style.cursor = "";
         return;
-    }
+    }*/
 	
 	if (maxIdx === 0) {
 		// => es gibt nur diesen einen Punkt

--- a/views/mainwindow.py
+++ b/views/mainwindow.py
@@ -1694,7 +1694,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": 0.0,
-                        "time": video_ts or now,
+                        "time": now,
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1712,7 +1712,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": gpx_data[0].get("ele", 0.0),
-                        "time": video_ts or new_time,
+                        "time": new_time,
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1721,8 +1721,7 @@ class MainWindow(QMainWindow):
                     gpx_data.insert(0, new_pt)
         
                     # jetzt alle nachfolgenden +1s verschieben
-                    if not video_ts:
-                        for i in range(1, len(gpx_data)):
+                    for i in range(1, len(gpx_data)):
                             oldt = gpx_data[i]["time"]
                             if oldt:
                                 gpx_data[i]["time"] = oldt + timedelta(seconds=1)
@@ -1735,7 +1734,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": 0.0,
-                        "time": video_ts or now,
+                        "time": now,
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1752,7 +1751,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": last_pt.get("ele", 0.0),
-                        "time": video_ts or new_time, 
+                        "time": new_time, 
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1773,7 +1772,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": 0.0,
-                        "time": video_ts or now,
+                        "time": now,
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1791,7 +1790,7 @@ class MainWindow(QMainWindow):
                         "lat": lat,
                         "lon": lon,
                         "ele": base_pt.get("ele", 0.0),
-                        "time": video_ts or new_time,
+                        "time": new_time,
                         "delta_m": 0.0,
                         "speed_kmh": 0.0,
                         "gradient": 0.0,
@@ -1803,8 +1802,7 @@ class MainWindow(QMainWindow):
                     gpx_data.insert(insert_pos, new_pt)
 
                     # alle folgenden => +1s
-                    if not video_ts:
-                        for j in range(insert_pos+1, len(gpx_data)):
+                    for j in range(insert_pos+1, len(gpx_data)):
                             t_old = gpx_data[j].get("time")
                             if t_old:
                                 gpx_data[j]["time"] = t_old + timedelta(seconds=1)      

--- a/widgets/video_editor_widget.py
+++ b/widgets/video_editor_widget.py
@@ -503,4 +503,7 @@ class VideoEditorWidget(QWidget):
         else:
             offset_prev = self.boundaries[clipIndex - 1]
     
-        return offset_prev + local_s    
+        return offset_prev + local_s   
+
+    def is_video_loaded(self) -> bool:
+        return self._player.playlist_count > 0


### PR DESCRIPTION
If activated in config, points created with "new" button have current video time and are automatically inserted in right position in the list